### PR TITLE
Feature mass message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ MESSENGER_APP_SECRET=1
 MESSENGER_VALIDATION_TOKEN=chave_forte_validacao
 MESSENGER_PAGE_ACCESS_TOKEN=a
 GRAPHQL_URL='http://localhost:3003/graphql'
+APP_DOMAIN='http://localhost:5000'
 
 # BONDE's credentials to make authenticated requests with GraphQL
 SERVER_AUTH_EMAIL='email'

--- a/bot/factory.js
+++ b/bot/factory.js
@@ -83,7 +83,7 @@ export default class BotFactory {
         bot.on('postback', botEvents.postback(...eventArgs))
         bot.on('message', botEvents.message(...eventArgs))
 
-        const endpoint = `/${data.name || id}`
+        const endpoint = `/${data.endpoint || id}`
 
         this.app.post(endpoint, botMiddlewares.saveReceivedInteraction(bot))
         this.app.get(endpoint, (req, res) => bot._verify(req, res))

--- a/bot/factory.js
+++ b/bot/factory.js
@@ -5,7 +5,6 @@ import * as graphqlQueries from '../graphql/queries'
 import * as graphqlMutations from '../graphql/mutations'
 import * as botEvents from './events'
 import * as botConfig from './config'
-import * as botMiddlewares from './middlewares'
 
 export default class BotFactory {
   //
@@ -77,22 +76,12 @@ export default class BotFactory {
 
         const bot = new Bot(config)
         const eventArgs = [bot, this.speech]
+        const endpoint = `/${data.endpoint || id}`
 
         bot.setGetStartedButton([{ payload: this.speech.actions.GET_STARTED }])
         bot.on('error', botEvents.error(...eventArgs))
         bot.on('postback', botEvents.postback(...eventArgs))
         bot.on('message', botEvents.message(...eventArgs))
-
-        const endpoint = `/${data.endpoint || id}`
-
-        this.app.post(endpoint, botMiddlewares.saveReceivedInteraction(bot))
-        this.app.get(endpoint, (req, res) => bot._verify(req, res))
-        this.app.post(endpoint, (req, res) => {
-          bot._handleMessage(req.body)
-          res.end(JSON.stringify({ status: 'ok' }))
-        })
-
-        console.log(`Bot[${id}] exposed in endpoints: ${endpoint}`.blue)
 
         return { id, bot, endpoint }
       })

--- a/bot/factory.js
+++ b/bot/factory.js
@@ -85,7 +85,7 @@ export default class BotFactory {
 
         const endpoint = `/${data.name || id}`
 
-        this.app.use(endpoint, botMiddlewares.saveReceivedInteraction(bot))
+        this.app.post(endpoint, botMiddlewares.saveReceivedInteraction(bot))
         this.app.get(endpoint, (req, res) => bot._verify(req, res))
         this.app.post(endpoint, (req, res) => {
           bot._handleMessage(req.body)

--- a/bot/middlewares/handle-message.js
+++ b/bot/middlewares/handle-message.js
@@ -1,0 +1,4 @@
+export default bot => (req, res) => {
+  bot._handleMessage(req.body)
+  res.end(JSON.stringify({ status: 'ok' }))
+}

--- a/bot/middlewares/index.js
+++ b/bot/middlewares/index.js
@@ -1,0 +1,1 @@
+export { default as saveReceivedInteraction } from './save-received-interaction'

--- a/bot/middlewares/index.js
+++ b/bot/middlewares/index.js
@@ -1,1 +1,3 @@
+export { default as handleMessage } from './handle-message'
 export { default as saveReceivedInteraction } from './save-received-interaction'
+export { default as verifyValidationToken } from './verify-validation-token'

--- a/bot/middlewares/index.js
+++ b/bot/middlewares/index.js
@@ -1,3 +1,4 @@
 export { default as handleMessage } from './handle-message'
 export { default as saveReceivedInteraction } from './save-received-interaction'
+export { default as sendMassMessage } from './send-mass-message'
 export { default as verifyValidationToken } from './verify-validation-token'

--- a/bot/middlewares/save-received-interaction.js
+++ b/bot/middlewares/save-received-interaction.js
@@ -1,0 +1,50 @@
+import 'colors'
+import escapeJSON from 'escape-json-node'
+import { client as graphqlClient } from '../../graphql'
+import * as graphqlMutations from '../../graphql/mutations'
+
+export default bot => (req, res, next) => {
+  //
+  // Snippet from `messenger-bot` package to identify
+  // the received message via payload
+  //
+  const entries = req.body.entry
+
+  entries.forEach((entry) => {
+    const events = entry.messaging
+
+    events.forEach((event) => {
+      if (event.message) {
+        if (!event.message.is_echo) {
+          bot.getProfile(event.sender.id, (err, profile) => {
+            if (err) {
+              console.log(JSON.stringify(err).red)
+              return next()
+            }
+
+            //
+            // In this case, the `sender.id` is the user's recipient.id
+            // and, the `recipient.id` is the page's recipient.id
+            //
+            const interaction = {
+              facebook_bot_configuration_id: Number(req.originalUrl.replace(/\D/g, '')),
+              fb_context_recipient_id: event.sender.id,
+              fb_context_sender_id: event.recipient.id,
+              interaction: {
+                profile,
+                event
+              }
+            }
+            graphqlClient.mutate({
+              mutation: graphqlMutations.createBotInteraction,
+              variables: { interaction: escapeJSON(JSON.stringify(interaction)) }
+            })
+              .then(data => data)
+              .catch(error => console.log(`${error}`.red))
+          })
+        }
+      }
+    })
+  })
+  next()
+}

--- a/bot/middlewares/save-received-interaction.js
+++ b/bot/middlewares/save-received-interaction.js
@@ -6,11 +6,11 @@ import * as graphqlMutations from '../../graphql/mutations'
 export default bot => (req, res, next) => {
   //
   // Snippet from `messenger-bot` package to identify
-  // the received message via payload
+  // the received message via payload on POST request
   //
   const entries = req.body.entry
 
-  entries.forEach((entry) => {
+  entries && entries.forEach((entry) => {
     const events = entry.messaging
 
     events.forEach((event) => {

--- a/bot/middlewares/send-mass-message.js
+++ b/bot/middlewares/send-mass-message.js
@@ -6,11 +6,11 @@ export default bot => (req, res) => {
       status: 'the post request do not have the body'
     }))
   } else {
-    const { activists, message: text } = req.body
-    const check = activists && activists.constructor === Array && text
+    const { recipients, message: text } = req.body
+    const check = recipients && recipients.constructor === Array && text
 
-    check && activists.forEach(
-      recipientId => bot.sendMessage(recipientId, { text })
+    check && recipients.forEach(
+      id => bot.sendMessage(id, { text })
     )
     res.end(JSON.stringify({ status: 'ok' }))
   }

--- a/bot/middlewares/send-mass-message.js
+++ b/bot/middlewares/send-mass-message.js
@@ -1,0 +1,17 @@
+import 'colors'
+
+export default bot => (req, res) => {
+  if (!req.body) {
+    res.end(JSON.stringify({
+      status: 'the post request do not have the body'
+    }))
+  } else {
+    const { activists, message: text } = req.body
+    const check = activists && activists.constructor === Array && text
+
+    check && activists.forEach(
+      recipientId => bot.sendMessage(recipientId, { text })
+    )
+    res.end(JSON.stringify({ status: 'ok' }))
+  }
+}

--- a/bot/middlewares/verify-validation-token.js
+++ b/bot/middlewares/verify-validation-token.js
@@ -1,0 +1,1 @@
+export default bot => (req, res) => bot._verify(req, res)

--- a/graphql/mutations/authenticate.js
+++ b/graphql/mutations/authenticate.js
@@ -1,9 +1,9 @@
 import gql from 'graphql-tag'
 
 export default gql`
-  mutation authenticate($email: String!, $password: String!) {
-    authenticate(input: { email: $email, password: $password }) {
-      jwtToken
-    }
+mutation authenticate($email: String!, $password: String!) {
+  authenticate(input: { email: $email, password: $password }) {
+    jwtToken
   }
+}
 `

--- a/graphql/mutations/create-bot-interaction.js
+++ b/graphql/mutations/create-bot-interaction.js
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag'
+
+export default gql`
+mutation createBotInteraction($interaction: Json!) {
+  createBotInteraction(input: {
+    botData: $interaction
+  }) {
+    interaction: json
+  }
+}
+`

--- a/graphql/mutations/index.js
+++ b/graphql/mutations/index.js
@@ -1,1 +1,2 @@
 export { default as authenticate } from './authenticate'
+export { default as createBotInteraction } from './create-bot-interaction'

--- a/graphql/queries/fetch-activists-last-interaction.js
+++ b/graphql/queries/fetch-activists-last-interaction.js
@@ -6,6 +6,7 @@ query fetchActivistsLastInteraction($facebookBotConfigurationId: Int) {
     condition: {
       facebookBotConfigurationId: $facebookBotConfigurationId
     }
+    orderBy: FACEBOOK_BOT_CONFIGURATION_ID_ASC
   ) {
     activists: nodes {
       id
@@ -15,6 +16,7 @@ query fetchActivistsLastInteraction($facebookBotConfigurationId: Int) {
       fbContextSenderId
       interaction
       facebookBotConfiguration
+      createdAt
     }
   }
 }

--- a/graphql/queries/fetch-activists-last-interaction.js
+++ b/graphql/queries/fetch-activists-last-interaction.js
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag'
+
+export default gql`
+query fetchActivistsLastInteraction($facebookBotConfigurationId: Int) {
+  activistsLastInteraction: allActivistFacebookBotInteractions(
+    condition: {
+      facebookBotConfigurationId: $facebookBotConfigurationId
+    }
+  ) {
+    activists: nodes {
+      id
+      activistId
+      communityId
+      fbContextRecipientId
+      fbContextSenderId
+      interaction
+      facebookBotConfiguration
+    }
+  }
+}
+`

--- a/graphql/queries/fetch-activists-last-interaction.js
+++ b/graphql/queries/fetch-activists-last-interaction.js
@@ -12,6 +12,7 @@ query fetchActivistsLastInteraction($facebookBotConfigurationId: Int) {
       id
       activistId
       communityId
+      facebookBotConfigurationId
       fbContextRecipientId
       fbContextSenderId
       interaction

--- a/graphql/queries/fetch-bot-recipients.js
+++ b/graphql/queries/fetch-bot-recipients.js
@@ -1,0 +1,22 @@
+import gql from 'graphql-tag'
+
+export default gql`
+query fetchBotRecipients($facebookBotConfigurationId: Int) {
+  botRecipients: allBotRecipients(
+    condition: {
+      facebookBotConfigurationId: $facebookBotConfigurationId
+    }
+    orderBy: FACEBOOK_BOT_CONFIGURATION_ID_ASC
+  ) {
+    recipients: nodes {
+      communityId
+      facebookBotConfigurationId
+      fbContextRecipientId
+      fbContextSenderId
+      interaction
+      facebookBotConfiguration
+      createdAt
+    }
+  }
+}
+`

--- a/graphql/queries/index.js
+++ b/graphql/queries/index.js
@@ -1,1 +1,2 @@
+export { default as fetchActivistsLastInteraction } from './fetch-activists-last-interaction'
 export { default as fetchBotConfigurations } from './fetch-bot-configurations'

--- a/graphql/queries/index.js
+++ b/graphql/queries/index.js
@@ -1,2 +1,2 @@
-export { default as fetchActivistsLastInteraction } from './fetch-activists-last-interaction'
+export { default as fetchBotRecipients } from './fetch-bot-recipients'
 export { default as fetchBotConfigurations } from './fetch-bot-configurations'

--- a/index.js
+++ b/index.js
@@ -43,17 +43,14 @@ const fabricated = new BotFactory(app, speech, credentials)
     //
     bots.forEach(({ id, bot, endpoint }) => {
       app.post(endpoint, botMiddlewares.saveReceivedInteraction(bot))
-      app.get(endpoint, (req, res) => bot._verify(req, res))
-      app.post(endpoint, (req, res) => {
-        bot._handleMessage(req.body)
-        res.end(JSON.stringify({ status: 'ok' }))
-      })
+      app.get(endpoint, botMiddlewares.verifyValidationToken(bot))
+      app.post(endpoint, botMiddlewares.handleMessage(bot))
       console.log(`Bot[${id}] exposed in endpoint: ${endpoint}`.blue)
     })
   })
 
 //
-// Express server endpoints
+// Express server routes
 //
 app.use('/login', routes.login)
 app.use('/mass-message', routes.massMessage)

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ const fabricated = new BotFactory(app, speech, credentials)
       app.post(endpoint, botMiddlewares.saveReceivedInteraction(bot))
       app.get(endpoint, botMiddlewares.verifyValidationToken(bot))
       app.post(endpoint, botMiddlewares.handleMessage(bot))
+      app.post(`${endpoint}/mass-message/send`, botMiddlewares.sendMassMessage(bot))
+
       console.log(`Bot[${id}] exposed in endpoint: ${endpoint}`.blue)
     })
   })

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ const fabricated = new BotFactory(app, speech, credentials)
 //
 // Express server routes
 //
+app.use('/', routes.massMessage)
 app.use('/login', routes.login)
 app.use('/mass-message', routes.massMessage)
 

--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ import * as routes from './routes'
 //
 // Setup Express server
 //
-let App = Express()
+let app = Express()
 
-App.set('view engine', 'pug')
-App.use(Express.static('public'))
-App.use(BodyParser.json())
-App.use(BodyParser.urlencoded({ extended: true }))
-App.use(ExpressSession({
+app.set('view engine', 'pug')
+app.use(Express.static('public'))
+app.use(BodyParser.json())
+app.use(BodyParser.urlencoded({ extended: true }))
+app.use(ExpressSession({
   secret : 's3Cur3',
   name : 'sessionId',
   resave: true,
@@ -34,35 +34,19 @@ const credentials = {
   email: process.env.SERVER_AUTH_EMAIL,
   password: process.env.SERVER_AUTH_PASSWORD
 }
-const fabricated = new BotFactory(speech, credentials)
-  .fabricate()
-  .then(endpoints => {
-    //
-    // Set up bots express endpoints
-    //
-    endpoints.forEach(({ id, bot, botEndpoint }) => {
-      const endpoint = `/${botEndpoint}`
-      App.get(endpoint, (req, res) => bot._verify(req, res))
-      App.post(endpoint, (req, res) => {
-        bot._handleMessage(req.body)
-        res.end(JSON.stringify({ status: 'ok' }))
-      })
-
-      console.log(`Bot[${id}] exposed in endpoints: ${endpoint}`.blue)
-    })
-  })
+const fabricated = new BotFactory(app, speech, credentials).fabricate()
 
 //
 // Express server endpoints
 //
-App.use('/login', routes.login)
-App.use('/mass-message', routes.massMessage)
+app.use('/login', routes.login)
+app.use('/mass-message', routes.massMessage)
 
 //
 // Up the server
 //
 fabricated.then(() => {
   const port = process.env.PORT || 5000
-  Http.createServer(App).listen(port)
+  Http.createServer(app).listen(port)
   console.log(`🤖  Bot server running at port ${port}`)
 })

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "config": "^1.20.4",
     "dotenv": "^4.0.0",
     "ejs": "^2.4.2",
+    "escape-json-node": "^1.0.8",
     "express": "^4.13.4",
     "express-session": "^1.15.3",
     "graphql-tag": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "body-parser": "^1.15.0",
     "colors": "^1.1.2",
     "config": "^1.20.4",
+    "dateformat": "^2.0.0",
     "dotenv": "^4.0.0",
     "ejs": "^2.4.2",
     "escape-json-node": "^1.0.8",

--- a/public/mass-message/index.css
+++ b/public/mass-message/index.css
@@ -1,0 +1,70 @@
+body {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  color: #fff;
+}
+.is-dark {
+  background-color: #F62459;
+  background-image: linear-gradient(rgba(25, 181, 254, 0.6),rgba(246, 36, 89, 0.6)),linear-gradient(rgba(0, 0, 0, 0.6),rgba(0, 0, 0, 0.6)), url('https://images.unsplash.com/photo-1440439307159-c3afc8a8e4ff?dpr=1&auto=format&crop=entropy&fit=crop&w=2000&h=1000&q=40');
+}
+.nav {
+  min-height: 92px;
+}
+.nav-item img {
+  border-radius: 5px;
+}
+.hero.is-dark a.nav-item {
+  position: relative;
+}
+.hero.is-dark a.nav-item.is-active::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 1px;
+  background-color: #fff;
+  bottom: 0;
+  left: 0;
+}
+.button .icon:first-child:last-child {
+  margin-right: 5px;
+}
+.brand-name {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-left: 1rem;
+  position: relative;
+  top: -1px;
+}
+.hero.is-dark .nav-item a:not(.button), .hero.is-dark a.nav-item {
+    color: #fff;
+    padding: 0 30px;
+}
+.nav-item {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #fff;
+}
+.nav-item .button{
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #fff;
+  background-color: transparent;
+  border: 2px solid #fff;
+  padding: 10px 20px;
+  height: 45px;
+}
+.promo-img {
+  background-image: url('https://scdn.androidcommunity.com/wp-content/uploads/2016/05/Messenger.jpg');
+  border-radius: 10px;
+  border: 10px solid #fff;
+  background-position: center;
+  background-size: cover;
+  background-blend-mode: screen;
+}
+.label {
+  color: #fff;
+  font-weight: normal;
+}
+.users-container {
+  max-height: 270px;
+  overflow: auto;
+}

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -1,4 +1,5 @@
 import express from 'express'
+import request from 'request'
 import dateformat from 'dateformat'
 import { isAuthenticated } from './middlewares'
 import { client as graphqlClient } from '../graphql'
@@ -12,6 +13,21 @@ router.get('/', isAuthenticated, (req, res) => {
       res.render('./mass-message/index', { activists, dateformat })
     })
     .catch(error => console.log(`${error}`.red))
+})
+
+router.post('/send', (req, res) => {
+  const { selected_activists: selectedActivists, message } = req.body
+
+  const promises = Object.keys(selectedActivists).map(key => {
+    const id = String(key).replace(/\D/g, '')
+    const endpoint = `${process.env.APP_DOMAIN}/${id}/mass-message/send`
+    const activists = selectedActivists[key]
+    return request.post(endpoint, { form: { activists, message } })
+  })
+
+  Promise.all(promises).then(result => {
+    res.redirect('/mass-message')
+  })
 })
 
 export default router

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -7,22 +7,22 @@ import * as graphqlQueries from '../graphql/queries'
 
 const router = express.Router()
 
-router.get('/', isAuthenticated, (req, res) => {
-  graphqlClient.query({ query: graphqlQueries.fetchActivistsLastInteraction })
-    .then(({ data: { activistsLastInteraction: { activists } } }) => {
-      res.render('./mass-message/index', { activists, dateformat })
+router.get('/', (req, res) => {
+  graphqlClient.query({ query: graphqlQueries.fetchBotRecipients })
+    .then(({ data: { botRecipients: { recipients } } }) => {
+      res.render('./mass-message/index', { recipients, dateformat })
     })
     .catch(error => console.log(`${error}`.red))
 })
 
 router.post('/send', (req, res) => {
-  const { selected_activists: selectedActivists, message } = req.body
+  const { selected_recipients: selectedRecipients, message } = req.body
 
-  const promises = Object.keys(selectedActivists).map(key => {
+  const promises = Object.keys(selectedRecipients).map(key => {
     const id = String(key).replace(/\D/g, '')
     const endpoint = `${process.env.APP_DOMAIN}/${id}/mass-message/send`
-    const activists = selectedActivists[key]
-    return request.post(endpoint, { form: { activists, message } })
+    const recipients = selectedRecipients[key]
+    return request.post(endpoint, { form: { recipients, message } })
   })
 
   Promise.all(promises).then(result => {

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -1,10 +1,17 @@
 import express from 'express'
+import dateformat from 'dateformat'
 import { isAuthenticated } from './middlewares'
+import { client as graphqlClient } from '../graphql'
+import * as graphqlQueries from '../graphql/queries'
 
 const router = express.Router()
 
 router.get('/', isAuthenticated, (req, res) => {
-  res.render('./mass-message/index')
+  graphqlClient.query({ query: graphqlQueries.fetchActivistsLastInteraction })
+    .then(({ data: { activistsLastInteraction: { activists } } }) => {
+      res.render('./mass-message/index', { activists, dateformat })
+    })
+    .catch(error => console.log(`${error}`.red))
 })
 
 export default router

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -7,7 +7,7 @@ import * as graphqlQueries from '../graphql/queries'
 
 const router = express.Router()
 
-router.get('/', (req, res) => {
+router.get('/', isAuthenticated, (req, res) => {
   graphqlClient.query({ query: graphqlQueries.fetchBotRecipients })
     .then(({ data: { botRecipients: { recipients } } }) => {
       res.render('./mass-message/index', { recipients, dateformat })

--- a/views/layout/index.pug
+++ b/views/layout/index.pug
@@ -9,7 +9,9 @@ html(lang="en")
       link(rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css')
       link(rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css')
     block metas
-      meta(name='viewport' content='width=device-width, user-scalable=no')
+      meta(charset='utf-8')
+      meta(http-equiv='X-UA-Compatible', content='IE=edge')
+      meta(name='viewport' content='width=device-width, initial-scale=1')
   body
     block header
     block content

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -37,7 +37,7 @@ block content
               action='/mass-message/send'
               v-on:submit='onSubmit($event)'
             )
-              if !activists.length
+              if !recipients.length
                 .notification.is-warning
                   b Nenhum usuário interagiu com a BETA até o momento.
                   |  Infelizmente não é possível enviar mensagem em massa.
@@ -51,35 +51,32 @@ block content
                       thead
                         tr
                           th
-                          th #
                           th Nome
                           th Origem
                           th Última Interação
                       tfoot
                         tr
                           th
-                          th #
                           th Nome
                           th Origem
                           th Última Interação
                       tbody
-                        each activist in activists
-                          - var botConfiguration = JSON.parse(activist.facebookBotConfiguration)
-                          - var interaction = JSON.parse(activist.interaction)
+                        each recipient in recipients
+                          - var botConfiguration = JSON.parse(recipient.facebookBotConfiguration)
+                          - var interaction = JSON.parse(recipient.interaction)
                           - var profile = interaction.profile
                           tr
                             th
                               label.checkbox
                                 input(
                                   type='checkbox'
-                                  name=`selected_activists['${activist.facebookBotConfigurationId}'][]`
-                                  value=activist.fbContextRecipientId
+                                  name=`selected_recipients['${recipient.facebookBotConfigurationId}'][]`
+                                  value=recipient.fbContextRecipientId
                                   checked
                                 )
-                            td= activist.id
                             td #{profile.first_name} #{profile.last_name}
                             td= botConfiguration.name
-                            td= dateformat(new Date(activist.createdAt), 'dd/mm/yyyy, H:M:ss')
+                            td= dateformat(new Date(recipient.createdAt), 'dd/mm/yyyy, H:M:ss')
 
                 .field
                   label.label Mensagem

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -86,9 +86,13 @@ block content
                   p.control
                     textarea.textarea(
                       autofocus
+                      v-model='message'
+                      v-bind:class="{ 'is-danger': !message && messageDirty, 'is-success': message }"
+                      v-on:keydown='onMessageKeydown'
                       name='message'
                       placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?'
                     )
+                  span.help.is-danger(v-if='!message && messageDirty') * Campo obrigatório
                   br
 
                 button.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth(
@@ -101,10 +105,22 @@ block content
   script(type='text/javascript').
     new Vue({
       el: '#mass-message',
+      data: {
+        message: undefined,
+        messageDirty: false
+      },
       methods: {
+        onMessageKeydown: function () { this.messageDirty = true },
         onSubmit: function (event) {
+          var validation = this.message
           var message = 'Dá uma olhada pra ver se tá tudo certo na mensagem pois,'
                       + 'depois de enviada, não tem que voltar atrás... Posso prosseguir?'
+
+          if (!validation) {
+            event.preventDefault()
+            this.messageDirty = true
+            return
+          }
           if (!confirm(message)) event.preventDefault()
         }
       }

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -1,10 +1,106 @@
 extends ../layout/index.pug
 
 block append stylesheets
-  link(rel='stylesheet' href='/login/index.css')
+  link(rel='stylesheet' href='/mass-message/index.css')
 
 block content
-  h1 mass message page
+  section.hero.is-fullheight.is-dark
+    .hero-head
+      .container
+        nav.nav
+          .container
+            .nav-left
+              a.nav-item.branding(href='../index.html')
+                img(src='https://scontent.fcgh12-1.fna.fbcdn.net/v/t1.0-9/18485498_463912997289183_6766375779007506020_n.png?oh=d70fe6affd9b823f09c64546fb253f44&oe=59CCAF85' alt='Beta logo')
+                .brand-name BETA
+            span.nav-toggle
+              span
+              span
+              span
+            .nav-right.nav-menu
+              a.nav-item.is-active Mensagem em massa
+    .hero-body
+      .container
+        .columns.is-vcentered
+          .column.is-5
+            figure.image.promo-img.is-4by3
+
+          .column.is-6.is-offset-1
+            h1.title.is-2.is-spaced
+              | Envio de mensagem em massa
+            h2.subtitle.is-5
+              | Você pode enviar uma mensagem em massa para todas as pessoas que interagiram
+              | com a BETA pelo Messenger do Facebook.
+
+            .field
+              label.label
+                | Usuários
+                a.button.is-light.is-small.is-pulled-right expandir
+              .users-container
+                table.table.is-striped
+                  thead
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      th #
+                      th Nome
+                      th Origem
+                  tfoot
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      th id
+                      th Nome
+                      th Origem
+                  tbody
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      td 1
+                      td Usuário 01
+                      td BETA
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      td 2
+                      td Usuário 02
+                      td Quebrando o Tabu
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      td 3
+                      td Usuário 03
+                      td BETA
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      td 4
+                      td Usuário 04
+                      td BETA
+                    tr
+                      th
+                        label.checkbox
+                          input(type='checkbox')
+                      td 5
+                      td Usuário 05
+                      td BETA
+
+            .field
+              label.label Mensagem
+              p.control
+                textarea.textarea(placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?')
+              br
+
+            a.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth
+              span.icon
+                i.fa.fa-envelope
+              | Enviar
 
   script(type='text/javascript').
     new Vue({

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -32,71 +32,80 @@ block content
               | Você pode enviar uma mensagem em massa para todas as pessoas que interagiram
               | com a BETA pelo Messenger do Facebook.
 
-            if !activists.length
-              .notification.is-warning
-                b Nenhum usuário interagiu com a BETA até o momento.
-                |  Infelizmente não é possível enviar mensagem em massa.
-            else
-              .field
-                label.label
-                  | Usuários
-                  a.button.is-light.is-small.is-pulled-right expandir
-                .users-container
-                  table.table.is-striped
-                    thead
-                      tr
-                        th #
-                        th Nome
-                        th Origem
-                        th Última Interação
-                    tfoot
-                      tr
-                        th #
-                        th Nome
-                        th Origem
-                        th Última Interação
-                    tbody
-                      each activist in activists
-                        - var botConfiguration = JSON.parse(activist.facebookBotConfiguration)
-                        - var interaction = JSON.parse(activist.interaction)
-                        - var profile = interaction.profile
+            form#mass-message(
+              method='post'
+              action='/mass-message/send'
+              v-on:submit='onSubmit($event)'
+            )
+              if !activists.length
+                .notification.is-warning
+                  b Nenhum usuário interagiu com a BETA até o momento.
+                  |  Infelizmente não é possível enviar mensagem em massa.
+              else
+                .field
+                  label.label
+                    | Usuários
+                    a.button.is-light.is-small.is-pulled-right expandir
+                  .users-container
+                    table.table.is-striped
+                      thead
                         tr
-                          td= activist.id
-                          td #{profile.first_name} #{profile.last_name}
-                          td= botConfiguration.name
-                          td= dateformat(new Date(activist.createdAt), 'dd/mm/yyyy, H:M:ss')
+                          th
+                          th #
+                          th Nome
+                          th Origem
+                          th Última Interação
+                      tfoot
+                        tr
+                          th
+                          th #
+                          th Nome
+                          th Origem
+                          th Última Interação
+                      tbody
+                        each activist in activists
+                          - var botConfiguration = JSON.parse(activist.facebookBotConfiguration)
+                          - var interaction = JSON.parse(activist.interaction)
+                          - var profile = interaction.profile
+                          tr
+                            th
+                              label.checkbox
+                                input(
+                                  type='checkbox'
+                                  name=`selected_activists['${activist.facebookBotConfigurationId}'][]`
+                                  value=activist.fbContextRecipientId
+                                  checked
+                                )
+                            td= activist.id
+                            td #{profile.first_name} #{profile.last_name}
+                            td= botConfiguration.name
+                            td= dateformat(new Date(activist.createdAt), 'dd/mm/yyyy, H:M:ss')
 
-              .field
-                label.label Mensagem
-                p.control
-                  textarea.textarea(placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?')
-                br
+                .field
+                  label.label Mensagem
+                  p.control
+                    textarea.textarea(
+                      autofocus
+                      name='message'
+                      placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?'
+                    )
+                  br
 
-              a.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth
-                span.icon
-                  i.fa.fa-envelope
-                | Enviar
+                button.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth(
+                  type='submit'
+                )
+                  span.icon
+                    i.fa.fa-envelope
+                  | Enviar
 
   script(type='text/javascript').
     new Vue({
-      el: '#login',
-      data: {
-        email: undefined,
-        emailDirty: false,
-        password: undefined,
-        passwordDirty: false
-      },
-      computed: {
-        validEmail: function () {
-          return /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(this.email)
-        }
-      },
+      el: '#mass-message',
       methods: {
-        onEmailFocus: function () { this.emailDirty = true },
-        onPasswordFocus: function () { this.passwordDirty = true },
         onSubmit: function (event) {
-          var validation = this.validEmail && this.password
-          if (!validation) event.preventDefault()
+          var message = 'Dá uma olhada pra ver se tá tudo certo na mensagem pois,'
+                      + 'depois de enviada, não tem que voltar atrás... Posso prosseguir?'
+          if (!confirm(message)) event.preventDefault()
         }
       }
     })

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -43,9 +43,7 @@ block content
                   |  Infelizmente não é possível enviar mensagem em massa.
               else
                 .field
-                  label.label
-                    | Usuários
-                    a.button.is-light.is-small.is-pulled-right expandir
+                  label.label Usuários
                   .users-container
                     table.table.is-striped
                       thead

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -32,75 +32,50 @@ block content
               | Você pode enviar uma mensagem em massa para todas as pessoas que interagiram
               | com a BETA pelo Messenger do Facebook.
 
-            .field
-              label.label
-                | Usuários
-                a.button.is-light.is-small.is-pulled-right expandir
-              .users-container
-                table.table.is-striped
-                  thead
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      th #
-                      th Nome
-                      th Origem
-                  tfoot
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      th id
-                      th Nome
-                      th Origem
-                  tbody
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      td 1
-                      td Usuário 01
-                      td BETA
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      td 2
-                      td Usuário 02
-                      td Quebrando o Tabu
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      td 3
-                      td Usuário 03
-                      td BETA
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      td 4
-                      td Usuário 04
-                      td BETA
-                    tr
-                      th
-                        label.checkbox
-                          input(type='checkbox')
-                      td 5
-                      td Usuário 05
-                      td BETA
+            if !activists.length
+              .notification.is-warning
+                b Nenhum usuário interagiu com a BETA até o momento.
+                |  Infelizmente não é possível enviar mensagem em massa.
+            else
+              .field
+                label.label
+                  | Usuários
+                  a.button.is-light.is-small.is-pulled-right expandir
+                .users-container
+                  table.table.is-striped
+                    thead
+                      tr
+                        th #
+                        th Nome
+                        th Origem
+                        th Última Interação
+                    tfoot
+                      tr
+                        th #
+                        th Nome
+                        th Origem
+                        th Última Interação
+                    tbody
+                      each activist in activists
+                        - var botConfiguration = JSON.parse(activist.facebookBotConfiguration)
+                        - var interaction = JSON.parse(activist.interaction)
+                        - var profile = interaction.profile
+                        tr
+                          td= activist.id
+                          td #{profile.first_name} #{profile.last_name}
+                          td= botConfiguration.name
+                          td= dateformat(new Date(activist.createdAt), 'dd/mm/yyyy, H:M:ss')
 
-            .field
-              label.label Mensagem
-              p.control
-                textarea.textarea(placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?')
-              br
+              .field
+                label.label Mensagem
+                p.control
+                  textarea.textarea(placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?')
+                br
 
-            a.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth
-              span.icon
-                i.fa.fa-envelope
-              | Enviar
+              a.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth
+                span.icon
+                  i.fa.fa-envelope
+                | Enviar
 
   script(type='text/javascript').
     new Vue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,6 +1409,10 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
+escape-json-node@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/escape-json-node/-/escape-json-node-1.0.8.tgz#db56cb150865ef4695dc07369820a50836671b6a"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,6 +1181,10 @@ dateformat@^1.0.11, dateformat@^1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
+dateformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
+
 debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"


### PR DESCRIPTION
# Related issues
- Form to sent mass message to facebook users #5

# How to test
- Access the `/` route
- If you are not authenticated, it should redirects to the `/login` route

| desktop | mobile |
|---|---|
| <img width="1674" alt="screen shot 2017-07-11 at 13 45 31" src="https://user-images.githubusercontent.com/5435389/28079563-45d6378c-663f-11e7-8877-2a768d25b37e.png"> | <img width="397" alt="screen shot 2017-07-11 at 13 48 00" src="https://user-images.githubusercontent.com/5435389/28079693-c0425ee2-663f-11e7-8980-ecf1162ad991.png"> |

- Otherwise, it should render the mass message page by default:

| desktop | mobile |
|---|---|
| <img width="1674" alt="screen shot 2017-07-12 at 16 46 23" src="https://user-images.githubusercontent.com/5435389/28136997-007082c2-6722-11e7-9ab4-07f2c241ae9b.png"> | ![localhost-5000-mass-message-](https://user-images.githubusercontent.com/5435389/28137010-0f1b6558-6722-11e7-8fdf-ad69805e3623.png) |

- Try to submit the form with the message field empty
- It should display a validation message:
<img width="711" alt="screen shot 2017-07-12 at 16 50 57" src="https://user-images.githubusercontent.com/5435389/28137069-556a5dde-6722-11e7-9199-a71c812d05ab.png">

- Fill the message field and submit the form
- It should display a confirmation message:
<img width="567" alt="screen shot 2017-07-12 at 16 52 36" src="https://user-images.githubusercontent.com/5435389/28137124-8a4c283e-6722-11e7-85aa-2205ab3c73a1.png">

- Click the **Cancel** button to cancel the form's submit
- Or click the **OK** button to send the message
- It should send the message to all recipients that are selected:
<img width="416" alt="screen shot 2017-07-12 at 16 54 41" src="https://user-images.githubusercontent.com/5435389/28137211-d79dc7f0-6722-11e7-85d9-80a37216ac82.png">
