### PR TITLE
Hotfix refetch recipient

### DIFF
--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -8,7 +8,10 @@ import * as graphqlQueries from '../graphql/queries'
 const router = express.Router()
 
 router.get('/', isAuthenticated, (req, res) => {
-  graphqlClient.query({ query: graphqlQueries.fetchBotRecipients })
+  graphqlClient.query({
+    fetchPolicy: 'network-only',
+    query: graphqlQueries.fetchBotRecipients
+  })
     .then(({ data: { botRecipients: { recipients } } }) => {
       res.render('./mass-message/index', { recipients, dateformat })
     })


### PR DESCRIPTION
# Related issues
- Fetch bot recipients when reload the mass message page #23

# How to test
- Acesse a rota `/mass-message` antes de interagir com a beta
- Faça uma interação com a beta pelo messenger do fb
- Recarregue a página
- O seu usuário deve estar listado na lista de usuários