### PR TITLE
Feature filter recipients by page config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["latest"]
+  "presets": ["latest"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,7 @@ pipeline:
   publish-staging:
     image: plugins/docker
     repo: nossas/bonde-bot
+    secrets: [ docker_username, docker_password ]
     username: lpirola
     password: ${DOCKER_PASSWORD}
     tags:
@@ -34,6 +35,7 @@ pipeline:
   publish-production:
     image: plugins/docker
     repo: nossas/bonde-bot
+    secrets: [ docker_username, docker_password ]
     username: lpirola
     password: ${DOCKER_PASSWORD}
     tags:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,8 +25,8 @@ pipeline:
     port: 22
     script:
       - sudo docker pull nossas/bonde-bot:${DRONE_BRANCH}
-      - sudo docker tag nossas/bonde-bot:${DRONE_BRANCH} dokku/bot:latest
-      - dokku tags:deploy bot latest
+      - sudo docker tag nossas/bonde-bot:${DRONE_BRANCH} dokku/beta:latest
+      - dokku tags:deploy beta latest
     when:
       status: success
       branch: [hotfix-*, release-*, feature-*, develop]
@@ -50,8 +50,8 @@ pipeline:
     port: 22
     script:
       - sudo docker pull nossas/bonde-bot:${DRONE_TAG##v}
-      - sudo docker tag nossas/bonde-bot:${DRONE_TAG##v} dokku/bot:latest
-      - dokku tags:deploy bot latest
+      - sudo docker tag nossas/bonde-bot:${DRONE_TAG##v} dokku/beta:latest
+      - dokku tags:deploy beta latest
     when:
       status: success
       event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,7 @@ pipeline:
     username: ubuntu
     command_timeout: 120
     port: 22
+    secrets: [ ssh_key ]
     script:
       - sudo docker pull nossas/bonde-bot:${DRONE_BRANCH}
       - sudo docker tag nossas/bonde-bot:${DRONE_BRANCH} dokku/beta:latest
@@ -50,6 +51,7 @@ pipeline:
     username: ubuntu
     command_timeout: 120
     port: 22
+    secrets: [ ssh_key ]
     script:
       - sudo docker pull nossas/bonde-bot:${DRONE_TAG##v}
       - sudo docker tag nossas/bonde-bot:${DRONE_TAG##v} dokku/beta:latest

--- a/graphql/queries/fetch-bot-configurations.js
+++ b/graphql/queries/fetch-bot-configurations.js
@@ -1,15 +1,16 @@
 import gql from 'graphql-tag'
 
 export default gql`
-  query fetchBotConfigurations {
-    configs: allFacebookBotConfigurations(orderBy: ID_ASC) {
-      bots: nodes {
-        id
-        messengerAppSecret
-        messengerValidationToken
-        messengerPageAccessToken
-        data
-      }
+query fetchBotConfigurations {
+  configs: allFacebookBotConfigurations(orderBy: ID_ASC) {
+    bots: nodes {
+      id
+      messengerAppSecret
+      messengerValidationToken
+      messengerPageAccessToken
+      data
+      createdAt
     }
   }
+}
 `

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "nodemon": "^1.11.0",
     "pug": "^2.0.0-rc.2",
     "request": "^2.72.0",
-    "standard": "^9.0.2"
+    "standard": "^9.0.2",
+    "underscore": "^1.8.3"
   },
   "engines": {
     "node": "~4.1.2"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "apollo-client": "^1.7.0",
     "babel-cli": "^6.24.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-latest": "^6.24.1",
     "babel-register": "^6.24.0",
     "body-parser": "^1.15.0",

--- a/public/mass-message/index.css
+++ b/public/mass-message/index.css
@@ -68,3 +68,8 @@ body {
   max-height: 500px;
   overflow: auto;
 }
+@media screen and (max-width: 768px) {
+  .hero.is-dark .nav-menu .nav-item {
+    padding: 30px;
+  }
+}

--- a/public/mass-message/index.css
+++ b/public/mass-message/index.css
@@ -68,6 +68,15 @@ body {
   max-height: 500px;
   overflow: auto;
 }
+.input.is-default,
+.textarea.is-default {
+      border-color: #fff;
+}
+.is-outlined.is-default {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
 @media screen and (max-width: 768px) {
   .hero.is-dark .nav-menu .nav-item {
     padding: 30px;

--- a/public/mass-message/index.css
+++ b/public/mass-message/index.css
@@ -73,3 +73,9 @@ body {
     padding: 30px;
   }
 }
+.help.is-danger {
+  background-color: #fff;
+  padding: 5px 20px;
+  border-radius: 3px;
+  font-weight: bold;
+}

--- a/public/mass-message/index.css
+++ b/public/mass-message/index.css
@@ -65,6 +65,6 @@ body {
   font-weight: normal;
 }
 .users-container {
-  max-height: 270px;
+  max-height: 500px;
   overflow: auto;
 }

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import request from 'request'
+import _ from 'underscore'
 import dateformat from 'dateformat'
 import { isAuthenticated } from './middlewares'
 import { client as graphqlClient } from '../graphql'
@@ -7,30 +8,66 @@ import * as graphqlQueries from '../graphql/queries'
 
 const router = express.Router()
 
-router.get('/', isAuthenticated, (req, res) => {
-  graphqlClient.query({
+// router.get('/', isAuthenticated, (req, res) => {
+router.get('/', (req, res) => {
+  const fetchBotConfigurations = graphqlClient.query({
+    fetchPolicy: 'network-only',
+    query: graphqlQueries.fetchBotConfigurations
+  })
+  const fetchBotRecipients = graphqlClient.query({
     fetchPolicy: 'network-only',
     query: graphqlQueries.fetchBotRecipients
   })
-    .then(({ data: { botRecipients: { recipients } } }) => {
-      res.render('./mass-message/index', { recipients, dateformat })
+
+  Promise.all([fetchBotConfigurations, fetchBotRecipients])
+    .then(values => {
+      const [botConfiguration, botRecipients] = values
+      const { data: { configs: { bots: botsRaw } } } = botConfiguration
+      const { data: { botRecipients: { recipients: recipientsRaw } } } = botRecipients
+      const date = date => dateformat(date, 'dd/mm/yyyy')
+      const time = date => dateformat(date, 'HH:MM')
+      const createAt = value => `${date(value)} às ${time(value)}`
+
+      const bots = botsRaw.map(bot => ({
+        ...bot,
+        data: JSON.parse(bot.data),
+        createdAt: createAt(bot.createdAt)
+      }))
+
+      const recipients = recipientsRaw.map(recipient => {
+        const interaction = JSON.parse(recipient.interaction)
+        return {
+          ...recipient,
+          interaction,
+          profile: interaction.profile,
+          bot: JSON.parse(recipient.facebookBotConfiguration),
+          createdAt: createAt(recipient.createdAt)
+        }
+      })
+      const appDomain = process.env.APP_DOMAIN
+
+      res.render('./mass-message/index', { bots, recipients, dateformat, appDomain })
     })
     .catch(error => console.log(`${error}`.red))
 })
 
 router.post('/send', (req, res) => {
-  const { selected_recipients: selectedRecipients, message } = req.body
+  const { selectedRecipients, message } = req.body
 
-  const promises = Object.keys(selectedRecipients).map(key => {
-    const id = String(key).replace(/\D/g, '')
-    const endpoint = `${process.env.APP_DOMAIN}/${id}/mass-message/send`
-    const recipients = selectedRecipients[key]
+  const grouping = _
+    .chain(selectedRecipients)
+    .groupBy('facebookBotConfigurationId')
+    .value()
+
+  const promises = _.toArray(_.mapObject(grouping, (value, key) => {
+    const endpoint = `${process.env.APP_DOMAIN}/${key}/mass-message/send`
+    const recipients = value.map(value => value.fbContextRecipientId)
     return request.post(endpoint, { form: { recipients, message } })
-  })
+  }))
 
-  Promise.all(promises).then(result => {
-    res.redirect('/mass-message')
-  })
+  Promise.all(promises)
+    .then(() => { res.end(JSON.stringify({ status: 'ok' })) })
+    .catch(err => console.log(`${err}`.red))
 })
 
 export default router

--- a/routes/mass-message.js
+++ b/routes/mass-message.js
@@ -8,8 +8,7 @@ import * as graphqlQueries from '../graphql/queries'
 
 const router = express.Router()
 
-// router.get('/', isAuthenticated, (req, res) => {
-router.get('/', (req, res) => {
+router.get('/', isAuthenticated, (req, res) => {
   const fetchBotConfigurations = graphqlClient.query({
     fetchPolicy: 'network-only',
     query: graphqlQueries.fetchBotConfigurations

--- a/views/layout/index.pug
+++ b/views/layout/index.pug
@@ -5,6 +5,7 @@ html(lang="en")
     block scripts
       script(src='https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.10/vue.min.js')
       script(src='https://cdnjs.cloudflare.com/ajax/libs/vuex/2.1.1/vuex.min.js')
+      script(src='https://cdnjs.cloudflare.com/ajax/libs/vue-resource/1.3.4/vue-resource.min.js')
     block stylesheets
       link(rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css')
       link(rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css')

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -21,102 +21,157 @@ block content
               a.nav-item.is-active Mensagem em massa
     .hero-body
       .container
-        .columns.is-vcentered
-          .column.is-5
-            figure.image.promo-img.is-4by3
+        form#mass-message(
+          v-on:submit='onSubmit($event)'
+        )
+          .columns
+            .column.is-12
+              h1.title.is-2.is-spaced
+                | Envio de mensagem em massa
+              h2.subtitle.is-5
+                | Você pode enviar uma mensagem em massa para todas as pessoas que interagiram
+                | com a BETA pelo Messenger do Facebook.
 
-          .column.is-6.is-offset-1
-            h1.title.is-2.is-spaced
-              | Envio de mensagem em massa
-            h2.subtitle.is-5
-              | Você pode enviar uma mensagem em massa para todas as pessoas que interagiram
-              | com a BETA pelo Messenger do Facebook.
+          .columns
+            .column.is-6
+              .notification.is-warning(v-if='!bots.length')
+                b Nenhum usuário interagiu com a BETA até o momento.
+                |  Infelizmente não é possível enviar mensagem em massa.
+              .field(v-else)
+                label.label Páginas
+                .users-container
+                  table.table.is-striped.is-medium
+                    thead
+                      tr
+                        th(style='width: 1px')
+                          label.checkbox
+                            input(type='checkbox' v-model='selectAll')
+                        th(style='width: 1px') #
+                        th Nome
+                        th Criado em
+                    tbody
+                      tr(v-for='bot in bots')
+                        th
+                          label.checkbox
+                            input(
+                              type='checkbox'
+                              v-bind:name="'selected_bots[' + bot.id + '][]'"
+                              v-bind:value='bot.id'
+                              v-model='selectedBots'
+                            )
+                        td {{ bot.id }}
+                        td {{ bot.data.name }}
+                        td {{ bot.createdAt }}
+              .field
+                label.label Mensagem
+                p.control
+                  textarea.textarea(
+                    autofocus
+                    v-model='message'
+                    v-bind:class="{ 'is-danger': !message && messageDirty, 'is-success': message }"
+                    v-on:keydown='onMessageKeydown'
+                    name='message'
+                    placeholder='Exemplo:\n\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?'
+                    style='min-height: 220px'
+                  )
+                span.help.is-danger(v-if='!message && messageDirty') * Campo obrigatório
 
-            form#mass-message(
-              method='post'
-              action='/mass-message/send'
-              v-on:submit='onSubmit($event)'
-            )
+              button.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth(
+                type='submit'
+              )
+                span.icon
+                  i.fa.fa-envelope
+                | Enviar
+
+            .column.is-6
               if !recipients.length
                 .notification.is-warning
                   b Nenhum usuário interagiu com a BETA até o momento.
                   |  Infelizmente não é possível enviar mensagem em massa.
               else
                 .field
-                  label.label Usuários
+                  label.label Usuários (#{recipients.length})
                   .users-container
                     table.table.is-striped
                       thead
                         tr
-                          th
+                          th(style='width: 1px')
                           th Nome
-                          th Origem
+                          th Página
                           th Última Interação
                       tfoot
                         tr
                           th
                           th Nome
-                          th Origem
+                          th Página
                           th Última Interação
                       tbody
-                        each recipient in recipients
-                          - var botConfiguration = JSON.parse(recipient.facebookBotConfiguration)
-                          - var interaction = JSON.parse(recipient.interaction)
-                          - var profile = interaction.profile
-                          tr
-                            th
-                              label.checkbox
-                                input(
-                                  type='checkbox'
-                                  name=`selected_recipients['${recipient.facebookBotConfigurationId}'][]`
-                                  value=recipient.fbContextRecipientId
-                                  checked
-                                )
-                            td #{profile.first_name} #{profile.last_name}
-                            td= botConfiguration.name
-                            td= dateformat(new Date(recipient.createdAt), 'dd/mm/yyyy, H:M:ss')
-
-                .field
-                  label.label Mensagem
-                  p.control
-                    textarea.textarea(
-                      autofocus
-                      v-model='message'
-                      v-bind:class="{ 'is-danger': !message && messageDirty, 'is-success': message }"
-                      v-on:keydown='onMessageKeydown'
-                      name='message'
-                      placeholder='Exemplo:\nE aí, mana, tudo bem? Meu nome é Betânia, mas pode me chamar de Beta. Sou uma robô que veio ao mundo para ajudar a viralizar as lutas feministas pelas redes - e já tem uma oportunidade no forno. Vamos lá?'
-                    )
-                  span.help.is-danger(v-if='!message && messageDirty') * Campo obrigatório
-                  br
-
-                button.button.is-outlined.is-large.is-primary.is-inverted.is-fullwidth(
-                  type='submit'
-                )
-                  span.icon
-                    i.fa.fa-envelope
-                  | Enviar
+                        tr(v-for='recipient in recipients')
+                          th
+                            label.checkbox
+                              input(
+                                type='checkbox'
+                                name="'selected_recipients[' + recipient.facebookBotConfigurationId + '][]'"
+                                value='recipient.fbContextRecipientId'
+                                checked
+                              )
+                          td {{ recipient.profile.first_name }} {{ recipient.profile.last_name }}
+                          td {{ recipient.bot.name }}
+                          td {{ recipient.createdAt }}
 
   script(type='text/javascript').
+    var appDomain = '#{appDomain}'
+
     new Vue({
       el: '#mass-message',
       data: {
+        bots: !{JSON.stringify(bots)},
+        recipients: !{JSON.stringify(recipients)},
         message: undefined,
-        messageDirty: false
+        messageDirty: false,
+        selectedBots: !{JSON.stringify(bots)}.map(b => b.id),
+        selectedRecipients: !{JSON.stringify(recipients)}.map(r => ({
+          facebookBotConfigurationId: r.facebookBotConfigurationId,
+          fbContextRecipientId: r.fbContextRecipientId
+        })),
+      },
+      computed: {
+        selectAll: {
+          get: function () {
+            return this.bots
+              ? this.selectedBots.length == this.bots.length
+              : false
+          },
+          set: function (value) {
+            var selectedBots = []
+            if (value) this.bots.forEach(function (bot) { selectedBots.push(bot.id) })
+            this.selectedBots = selectedBots
+          }
+        }
       },
       methods: {
         onMessageKeydown: function () { this.messageDirty = true },
-        onSubmit: function (event) {
+        onSubmit: function(event) {
+          event.preventDefault()
           var validation = this.message
           var message = 'Dá uma olhada pra ver se tá tudo certo na mensagem pois,'
                       + 'depois de enviada, não tem que voltar atrás... Posso prosseguir?'
 
           if (!validation) {
-            event.preventDefault()
             this.messageDirty = true
             return
           }
-          if (!confirm(message)) event.preventDefault()
+          if (confirm(message)) {
+            var endpoint = appDomain + '/mass-message/send'
+            var payload = {
+              selectedRecipients: this.selectedRecipients,
+              message: this.message
+            }
+
+            this.$http.post(endpoint, payload)
+              .then(data => data)
+              .catch(err => console.error(err))
+          }
         }
       }
     })

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -10,7 +10,7 @@ block content
         nav.nav
           .container
             .nav-left
-              a.nav-item.branding(href='../index.html')
+              a.nav-item.branding(href='/')
                 img(src='https://scontent.fcgh12-1.fna.fbcdn.net/v/t1.0-9/18485498_463912997289183_6766375779007506020_n.png?oh=d70fe6affd9b823f09c64546fb253f44&oe=59CCAF85' alt='Beta logo')
                 .brand-name BETA
             span.nav-toggle
@@ -18,7 +18,7 @@ block content
               span
               span
             .nav-right.nav-menu
-              a.nav-item.is-active Mensagem em massa
+              a.nav-item.is-active(href='/mass-message') Mensagem em massa
     .hero-body
       .container
         form#mass-message(

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -7,23 +7,21 @@ block content
   section.hero.is-fullheight.is-dark
     .hero-head
       .container
-        nav.nav
+        nav#nav.nav
           .container
             .nav-left
               a.nav-item.branding(href='/')
                 img(src='https://scontent.fcgh12-1.fna.fbcdn.net/v/t1.0-9/18485498_463912997289183_6766375779007506020_n.png?oh=d70fe6affd9b823f09c64546fb253f44&oe=59CCAF85' alt='Beta logo')
                 .brand-name BETA
-            span.nav-toggle
+            span.nav-toggle(v-on:click='onToggleMenu')
               span
               span
               span
-            .nav-right.nav-menu
-              a.nav-item.is-active(href='/mass-message') Mensagem em massa
+            .nav-right.nav-menu(v-bind:class="{ 'is-active': isActive }")
+              a.nav-item(href='/mass-message') Mensagem em massa
     .hero-body
       .container
-        form#mass-message(
-          v-on:submit='onSubmit($event)'
-        )
+        form#form(v-on:submit='onSubmit($event)')
           .columns
             .column.is-12
               h1.title.is-2.is-spaced
@@ -132,10 +130,22 @@ block content
                   | * Campo obrigatório
 
   script(type='text/javascript').
+    new Vue({
+      el: '#nav',
+      data: {
+        isActive: false
+      },
+      methods: {
+        onToggleMenu: function() {
+          this.isActive = !this.isActive
+        }
+      }
+    })
+
     var appDomain = '#{appDomain}'
 
     new Vue({
-      el: '#mass-message',
+      el: '#form',
       data: {
         bots: !{JSON.stringify(bots)},
         allRecipients: !{JSON.stringify(recipients)},

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -84,7 +84,28 @@ block content
 
             .column.is-6
               .field
-                label.label Usuários ({{ selectedRecipients.length }})
+                label.label
+                  .columns.is-marginless
+                    .column.is-6.is-paddingless
+                      | Usuários ({{ selectedRecipients.length }})
+
+                    .column.is-6.is-paddingless(style='margin-bottom: -3px;')
+                      .field.is-pulled-right(v-bind:class="{ 'has-addons': isActiveSearch }")
+                        p.control
+                          a.button.is-outlined.is-default.is-small(
+                            v-on:click='onToggleSearch'
+                          )
+                            span.icon.is-small.is-marginless
+                              i.fa.fa-search(style='position: relative; top: -1px;')
+                        p.control(v-bind:class="{ 'is-hidden': !isActiveSearch }")
+                          input.input.is-small.is-default(
+                            type='text'
+                            placeholder='Nome de usuário'
+                            style='width: 200px;'
+                            ref='searchInput'
+                            v-model='search'
+                          )
+
                 .notification.is-warning(v-if='!bots.length && !recipients.length')
                   b Nenhum usuário interagiu com a BETA até o momento.
                   |  Infelizmente não é possível enviar mensagem em massa.
@@ -94,7 +115,7 @@ block content
                   |  selecionar uma ou mais páginas para que seja possível a listagem
                   |  dos usuários.
                 .users-container(v-else='recipients.length')
-                  table.table.is-striped
+                  table.table.is-striped.is-marginless
                     thead
                       tr
                         th(style='width: 1px')
@@ -112,13 +133,13 @@ block content
                         th Página
                         th Última Interação
                     tbody
-                      tr(v-for='recipient in recipients')
+                      tr(v-for='recipient in visibleRecipients')
                         th
                           label.checkbox
                             input(
                               type='checkbox'
                               v-bind:name="'selected_recipients[' + recipient.facebookBotConfigurationId + '][]'"
-                              v-bind:value='{ facebookBotConfigurationId: recipient.facebookBotConfigurationId, fbContextRecipientId: recipient.fbContextRecipientId }'
+                              v-bind:value='recipient'
                               v-model='selectedRecipients'
                               v-on:change='onRecipientChange'
                               checked
@@ -136,7 +157,7 @@ block content
         isActive: false
       },
       methods: {
-        onToggleMenu: function() {
+        onToggleMenu () {
           this.isActive = !this.isActive
         }
       }
@@ -146,69 +167,89 @@ block content
 
     new Vue({
       el: '#form',
+      beforeMount () {
+        this.recipients = this.visibleRecipients = this.allRecipients.filter(
+          r => this.selectedBots.includes(r.facebookBotConfigurationId)
+        )
+      },
       data: {
         bots: !{JSON.stringify(bots)},
         allRecipients: !{JSON.stringify(recipients)},
+        recipients: [],
+        visibleRecipients: [],
         message: undefined,
         messageDirty: false,
         recipientDirty: false,
         selectedBots: !{JSON.stringify(bots)}.map(b => b.id),
-        selectedRecipients: !{JSON.stringify(recipients)}
-          .map(r => ({
-            facebookBotConfigurationId: r.facebookBotConfigurationId,
-            fbContextRecipientId: r.fbContextRecipientId
-          })),
+        selectedRecipients: !{JSON.stringify(recipients)},
+        isActiveSearch: false,
+        search: '',
+      },
+      watch: {
+        selectedBots (val, old) {
+          this.recipients = this.visibleRecipients = this.allRecipients
+            .filter(r => val.includes(r.facebookBotConfigurationId))
+
+          this.visibleRecipients = !this.search
+            ? this.recipients
+            : this.recipients.filter(({
+                profile: {
+                  first_name: firstName,
+                  last_name: lastName
+                }
+              }) => {
+                const name = `${firstName} ${lastName}`
+                const regex = new RegExp(String(this.search).trim(), 'gi')
+                return name.match(regex)
+              }
+            )
+        },
+        search (val, old) {
+          this.visibleRecipients = !val
+            ? this.recipients
+            : this.recipients.filter(({
+                profile: {
+                  first_name: firstName,
+                  last_name: lastName
+                }
+              }) => {
+                const name = `${firstName} ${lastName}`
+                const regex = new RegExp(String(this.search).trim(), 'gi')
+                return name.match(regex)
+              }
+            )
+        },
       },
       computed: {
-        recipients: {
-          get: function() {
-            return this.allRecipients.filter(
-              r => this.selectedBots.includes(r.facebookBotConfigurationId)
-            )
-          }
-        },
         selectAllBots: {
-          get: function () {
+          get () {
             return this.bots
               ? this.selectedBots.length == this.bots.length
               : false
           },
-          set: function (value) {
+          set (value) {
             var selected = []
-            if (value) this.bots.forEach(function (b) { selected.push(b.id) })
+            if (value) this.bots.forEach(bot => selected.push(bot.id))
             this.selectedBots = selected
-            this.selectedRecipients = this.allRecipients
-              .filter(r => selected.includes(r.facebookBotConfigurationId))
-              .map(r => ({
-                facebookBotConfigurationId: r.facebookBotConfigurationId,
-                fbContextRecipientId: r.fbContextRecipientId
-              }))
           }
         },
         selectAllRecipients: {
-          get: function () {
+          get () {
             return this.recipients
               ? this.selectedRecipients.length == this.recipients.length
               : false
           },
-          set: function (value) {
+          set (value) {
             var selected = []
-            if (value) {
-              this.recipients.forEach(function (r) {
-                selected.push({
-                  facebookBotConfigurationId: r.facebookBotConfigurationId,
-                  fbContextRecipientId: r.fbContextRecipientId
-                })
-              })
-            }
+            if (value) this.recipients.forEach(recipient => { selected.push(recipient) })
             this.selectedRecipients = selected
           }
         }
       },
       methods: {
-        onMessageKeydown: function () { this.messageDirty = true },
-        onRecipientChange: function() { this.recipientDirty = true },
-        onSubmit: function(event) {
+        onMessageKeydown () { this.messageDirty = true },
+        onRecipientChange () { this.recipientDirty = true },
+        onSubmit (event) {
           event.preventDefault()
           var validation = this.message && this.selectedRecipients.length
           var message = 'Dá uma olhada pra ver se tá tudo certo na mensagem pois,'
@@ -231,13 +272,15 @@ block content
               .catch(err => console.error(err))
           }
         },
-        onChangeSelectedBots: function() {
+        onChangeSelectedBots () {
           this.selectedRecipients = this.allRecipients
             .filter(r => this.selectedBots.includes(r.facebookBotConfigurationId))
-            .map(r => ({
-              facebookBotConfigurationId: r.facebookBotConfigurationId,
-              fbContextRecipientId: r.fbContextRecipientId
-            }))
+        },
+        onToggleSearch (event) {
+          const self = this
+          event.preventDefault()
+          this.isActiveSearch = !this.isActiveSearch
+          if (this.isActiveSearch) setTimeout(() => self.$refs.searchInput.focus(), 1)
         }
       }
     })

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -106,15 +106,15 @@ block content
                             v-model='search'
                           )
 
-                .notification.is-warning(v-if='!bots.length && !recipients.length')
+                .notification.is-warning.is-marginless(v-if='!allRecipients.length')
                   b Nenhum usuário interagiu com a BETA até o momento.
                   |  Infelizmente não é possível enviar mensagem em massa.
-                .notification.is-warning(v-if='!recipients.length')
+                .notification.is-warning.is-marginless(v-if='!recipients.length && allRecipients.length')
                   b Nenhuma página foi selecionada.
                   |  Pra poder enviar mensagem para os usuários, você precisa
                   |  selecionar uma ou mais páginas para que seja possível a listagem
                   |  dos usuários.
-                .users-container(v-else='recipients.length')
+                .users-container(v-if='recipients.length')
                   table.table.is-striped.is-marginless
                     thead
                       tr

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -85,7 +85,7 @@ block content
             .column.is-6
               .field
                 label.label
-                  .columns.is-marginless
+                  .columns.is-marginless.is-mobile
                     .column.is-6.is-paddingless
                       | Usuários ({{ selectedRecipients.length }})
 

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -34,18 +34,18 @@ block content
 
           .columns
             .column.is-6
-              .notification.is-warning(v-if='!bots.length')
-                b Nenhum usuário interagiu com a BETA até o momento.
-                |  Infelizmente não é possível enviar mensagem em massa.
-              .field(v-else)
+              .field
                 label.label Páginas
-                .users-container
+                .notification.is-warning(v-if='!bots.length')
+                  b Nenhum usuário interagiu com a BETA até o momento.
+                  |  Infelizmente não é possível enviar mensagem em massa.
+                .users-container(v-else)
                   table.table.is-striped.is-medium
                     thead
                       tr
                         th(style='width: 1px')
                           label.checkbox
-                            input(type='checkbox' v-model='selectAll')
+                            input(type='checkbox' v-model='selectAllBots')
                         th(style='width: 1px') #
                         th Nome
                         th Criado em
@@ -58,6 +58,7 @@ block content
                               v-bind:name="'selected_bots[' + bot.id + '][]'"
                               v-bind:value='bot.id'
                               v-model='selectedBots'
+                              v-on:change='onChangeSelectedBots'
                             )
                         td {{ bot.id }}
                         td {{ bot.data.name }}
@@ -84,40 +85,51 @@ block content
                 | Enviar
 
             .column.is-6
-              if !recipients.length
-                .notification.is-warning
+              .field
+                label.label Usuários ({{ selectedRecipients.length }})
+                .notification.is-warning(v-if='!bots.length && !recipients.length')
                   b Nenhum usuário interagiu com a BETA até o momento.
                   |  Infelizmente não é possível enviar mensagem em massa.
-              else
-                .field
-                  label.label Usuários (#{recipients.length})
-                  .users-container
-                    table.table.is-striped
-                      thead
-                        tr
-                          th(style='width: 1px')
-                          th Nome
-                          th Página
-                          th Última Interação
-                      tfoot
-                        tr
-                          th
-                          th Nome
-                          th Página
-                          th Última Interação
-                      tbody
-                        tr(v-for='recipient in recipients')
-                          th
-                            label.checkbox
-                              input(
-                                type='checkbox'
-                                name="'selected_recipients[' + recipient.facebookBotConfigurationId + '][]'"
-                                value='recipient.fbContextRecipientId'
-                                checked
-                              )
-                          td {{ recipient.profile.first_name }} {{ recipient.profile.last_name }}
-                          td {{ recipient.bot.name }}
-                          td {{ recipient.createdAt }}
+                .notification.is-warning(v-if='!recipients.length')
+                  b Nenhuma página foi selecionada.
+                  |  Pra poder enviar mensagem para os usuários, você precisa
+                  |  selecionar uma ou mais páginas para que seja possível a listagem
+                  |  dos usuários.
+                .users-container(v-else='recipients.length')
+                  table.table.is-striped
+                    thead
+                      tr
+                        th(style='width: 1px')
+                          label.checkbox
+                            input(type='checkbox' v-model='selectAllRecipients')
+                        th Nome
+                        th Página
+                        th Última Interação
+                    tfoot
+                      tr
+                        th(style='width: 1px')
+                          label.checkbox
+                            input(type='checkbox' v-model='selectAllRecipients')
+                        th Nome
+                        th Página
+                        th Última Interação
+                    tbody
+                      tr(v-for='recipient in recipients')
+                        th
+                          label.checkbox
+                            input(
+                              type='checkbox'
+                              v-bind:name="'selected_recipients[' + recipient.facebookBotConfigurationId + '][]'"
+                              v-bind:value='{ facebookBotConfigurationId: recipient.facebookBotConfigurationId, fbContextRecipientId: recipient.fbContextRecipientId }'
+                              v-model='selectedRecipients'
+                              v-on:change='onRecipientChange'
+                              checked
+                            )
+                        td {{ recipient.profile.first_name }} {{ recipient.profile.last_name }}
+                        td {{ recipient.bot.name }}
+                        td {{ recipient.createdAt }}
+                span.help.is-danger(v-if='(!recipients.length || !selectedRecipients.length) && recipientDirty')
+                  | * Campo obrigatório
 
   script(type='text/javascript').
     var appDomain = '#{appDomain}'
@@ -126,39 +138,75 @@ block content
       el: '#mass-message',
       data: {
         bots: !{JSON.stringify(bots)},
-        recipients: !{JSON.stringify(recipients)},
+        allRecipients: !{JSON.stringify(recipients)},
         message: undefined,
         messageDirty: false,
+        recipientError: false,
         selectedBots: !{JSON.stringify(bots)}.map(b => b.id),
-        selectedRecipients: !{JSON.stringify(recipients)}.map(r => ({
-          facebookBotConfigurationId: r.facebookBotConfigurationId,
-          fbContextRecipientId: r.fbContextRecipientId
-        })),
+        selectedRecipients: !{JSON.stringify(recipients)}
+          .map(r => ({
+            facebookBotConfigurationId: r.facebookBotConfigurationId,
+            fbContextRecipientId: r.fbContextRecipientId
+          })),
       },
       computed: {
-        selectAll: {
+        recipients: {
+          get: function() {
+            return this.allRecipients.filter(
+              r => this.selectedBots.includes(r.facebookBotConfigurationId)
+            )
+          }
+        },
+        selectAllBots: {
           get: function () {
             return this.bots
               ? this.selectedBots.length == this.bots.length
               : false
           },
           set: function (value) {
-            var selectedBots = []
-            if (value) this.bots.forEach(function (bot) { selectedBots.push(bot.id) })
-            this.selectedBots = selectedBots
+            var selected = []
+            if (value) this.bots.forEach(function (b) { selected.push(b.id) })
+            this.selectedBots = selected
+            this.selectedRecipients = this.allRecipients
+              .filter(r => selected.includes(r.facebookBotConfigurationId))
+              .map(r => ({
+                facebookBotConfigurationId: r.facebookBotConfigurationId,
+                fbContextRecipientId: r.fbContextRecipientId
+              }))
+          }
+        },
+        selectAllRecipients: {
+          get: function () {
+            return this.recipients
+              ? this.selectedRecipients.length == this.recipients.length
+              : false
+          },
+          set: function (value) {
+            var selected = []
+            if (value) {
+              this.recipients.forEach(function (r) {
+                selected.push({
+                  facebookBotConfigurationId: r.facebookBotConfigurationId,
+                  fbContextRecipientId: r.fbContextRecipientId
+                })
+              })
+            }
+            this.selectedRecipients = selected
           }
         }
       },
       methods: {
         onMessageKeydown: function () { this.messageDirty = true },
+        onRecipientChange: function() { this.recipientDirty = true },
         onSubmit: function(event) {
           event.preventDefault()
-          var validation = this.message
+          var validation = this.message && this.selectedRecipients.length
           var message = 'Dá uma olhada pra ver se tá tudo certo na mensagem pois,'
                       + 'depois de enviada, não tem que voltar atrás... Posso prosseguir?'
 
           if (!validation) {
             this.messageDirty = true
+            this.recipientDirty = true
             return
           }
           if (confirm(message)) {
@@ -172,6 +220,14 @@ block content
               .then(data => data)
               .catch(err => console.error(err))
           }
+        },
+        onChangeSelectedBots: function() {
+          this.selectedRecipients = this.allRecipients
+            .filter(r => this.selectedBots.includes(r.facebookBotConfigurationId))
+            .map(r => ({
+              facebookBotConfigurationId: r.facebookBotConfigurationId,
+              fbContextRecipientId: r.fbContextRecipientId
+            }))
         }
       }
     })

--- a/views/mass-message/index.pug
+++ b/views/mass-message/index.pug
@@ -141,7 +141,7 @@ block content
         allRecipients: !{JSON.stringify(recipients)},
         message: undefined,
         messageDirty: false,
-        recipientError: false,
+        recipientDirty: false,
         selectedBots: !{JSON.stringify(bots)}.map(b => b.id),
         selectedRecipients: !{JSON.stringify(recipients)}
           .map(r => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3891,6 +3891,10 @@ undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
 
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -590,6 +594,13 @@ babel-plugin-transform-exponentiation-operator@^6.24.1:
   dependencies:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-regenerator@^6.24.1:


### PR DESCRIPTION
# Related issues
- Feature to filter the bot recipients by fb's page config #25

# How to test
Caso de teste por funcionalidade

## Filter by page
- Acesse o sistema de envio de mensagem em massa da BETA
- Faça login
- Além da listagem de usuários, agora também deverão ser listadas as páginas conectadas com o bot da BETA de acordo com o screenshot abaixo:

| desktop | mobile |
|---|---|
| <img width="1675" alt="screen shot 2017-07-14 at 10 49 58" src="https://user-images.githubusercontent.com/5435389/28214838-42e88a08-6882-11e7-89ee-9d7bdc5a0651.png"> | ![beta staging bonde org- 2](https://user-images.githubusercontent.com/5435389/28215167-615e0264-6883-11e7-9fa0-1b5b4e5849fb.png) |

- Valide as validações
  - Não é possível enviar mensagem em massa se nenhum usuário interagiu com a beta:
<img width="679" alt="screen shot 2017-07-14 at 10 46 07" src="https://user-images.githubusercontent.com/5435389/28214711-bf14d268-6881-11e7-964a-a0cd3e5ccea9.png">

  - Não é possível enviar mensagem em massa sem ter selecionado ao menos uma página:
<img width="684" alt="screen shot 2017-07-14 at 10 47 15" src="https://user-images.githubusercontent.com/5435389/28214735-d8ca4b52-6881-11e7-9afb-6d53daba54be.png">

  - Não é possível enviar mensagem em massa sem ter selecionado ao menos um usuário:
<img width="690" alt="screen shot 2017-07-14 at 10 47 47" src="https://user-images.githubusercontent.com/5435389/28214752-e7beb602-6881-11e7-81c3-bf1eb9848f83.png">

  - Não é possível enviar mensagem em massa sem ter preenchido o campo **mensagem**
<img width="679" alt="screen shot 2017-07-14 at 10 48 13" src="https://user-images.githubusercontent.com/5435389/28214771-f5da43c8-6881-11e7-89c8-5ad926eb0d08.png">

## Filter by user's name
- Acesse o sistema de envio de mensagem em massa da BETA
- Faça login
- Um campo de busca por nome de usuário deve estar presente na seção de usuários:
<img width="683" alt="screen shot 2017-07-14 at 10 29 40" src="https://user-images.githubusercontent.com/5435389/28214121-6ab71020-687f-11e7-9f38-dd8567edc10a.png">

- Clique no botão com ícone de lupa. Deverá abrir um campo de tipo texto já com o foco habilitado:
<img width="684" alt="screen shot 2017-07-14 at 10 29 55" src="https://user-images.githubusercontent.com/5435389/28214148-7eba8278-687f-11e7-8abf-3c232c183b44.png">

- Pesquise pelo nome do usuário que deseja e deverá "sumir" os outros usuários:
**Atenção:** a quantidade de usuário selecionados deve permanecer a mesma neste passo
<img width="687" alt="screen shot 2017-07-14 at 10 31 52" src="https://user-images.githubusercontent.com/5435389/28214192-acb61b06-687f-11e7-8a0e-6b8c78aa8ed6.png">

- Desmarque o usuário filtrado. Daí então o contador de usuários selecionados deve ser atualizado:
<img width="691" alt="screen shot 2017-07-14 at 10 32 56" src="https://user-images.githubusercontent.com/5435389/28214233-d28a9104-687f-11e7-819d-ea896ee8e96d.png">

- Ao apagar o conteúdo do campo de filtro por nome de usuário, todos os usuários das páginas selecionadas devem ser listados, com sua respectiva seleção corretamente:
<img width="683" alt="screen shot 2017-07-14 at 10 33 15" src="https://user-images.githubusercontent.com/5435389/28214263-f1e4f3c8-687f-11e7-9538-3a5dcb48f9ea.png">

- Preencha o campo mensagem e envie a mensagem em massa para os usuários selecionados.