### PR TITLE
fix(graphql): Fix typo in query facebook create campaign

### DIFF
--- a/graphql/mutations/create-facebook-bot-campaign.js
+++ b/graphql/mutations/create-facebook-bot-campaign.js
@@ -15,7 +15,7 @@ mutation createFacebookBotCampaign(
       totalImpactedActivists: $totalImpactedActivists
     }
   }) {
-    campaign: facebookBotCampaigns {
+    campaign: facebookBotCampaign {
       id
       facebookBotConfigurationId
       name

--- a/graphql/mutations/update-facebook-bot-campaign-activists.js
+++ b/graphql/mutations/update-facebook-bot-campaign-activists.js
@@ -11,7 +11,7 @@ mutation updateFacebookBotCampaignActivists(
     ctxReceived: $received,
     ctxLog: $log
   }) {
-    facebookBotCampaignActivists {
+    facebookBotCampaignActivist {
       id
       facebookBotCampaignId
       facebookBotActivistId


### PR DESCRIPTION
Problema: Query no graphql para criar companha no facebook está retornando erro.

Solução: Atualizar query.